### PR TITLE
Add advanced filters to the cloudtrail code

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,12 +38,12 @@ resource "aws_cloudtrail" "default" {
         for_each = lookup(advanced_event_selector.value, "field_selector", [])
         content {
           field           = field_selector.value.field
-          equals          = field_selector.value.equals
-          not_equals      = field_selector.value.not_equals
-          starts_with     = field_selector.value.starts_with
-          not_starts_with = field_selector.value.not_starts_with
-          ends_with       = field_selector.value.ends_with
-          not_ends_with   = field_selector.value.not_ends_with
+          equals          = lookup(field_selector.value, "equals", null)
+          not_equals      = lookup(field_selector.value, "not_equals", null)
+          starts_with     = lookup(field_selector.value, "starts_with", null)
+          not_starts_with = lookup(field_selector.value, "not_starts_with", null)
+          ends_with       = lookup(field_selector.value, "ends_with", null)
+          not_ends_with   = lookup(field_selector.value, "not_ends_with", null)
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -33,18 +33,8 @@ resource "aws_cloudtrail" "default" {
     for_each = var.advanced_event_selector
     content {
       name = lookup(advanced_event_selector.value, "name", null)
-
       dynamic "field_selector" {
         for_each = lookup(advanced_event_selector.value, "field_selector", [])
-        content {
-          field           = field_selector.value.field
-          equals          = field_selector.value.equals
-          not_equals      = field_selector.value.not_equals
-          starts_with     = field_selector.value.starts_with
-          not_starts_with = field_selector.value.not_starts_with
-          ends_with       = field_selector.value.ends_with
-          not_ends_with   = field_selector.value.not_ends_with
-        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,13 @@ resource "aws_cloudtrail" "default" {
     for_each = var.advanced_event_selector
     content {
       name = lookup(advanced_event_selector.value, "name", null)
+
       dynamic "field_selector" {
         for_each = lookup(advanced_event_selector.value, "field_selector", [])
+        content {
+          field     = field_selector.value.field
+          condition = field_selector.value.condition
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -37,8 +37,13 @@ resource "aws_cloudtrail" "default" {
       dynamic "field_selector" {
         for_each = lookup(advanced_event_selector.value, "field_selector", [])
         content {
-          field     = field_selector.value.field
-          condition = field_selector.value.condition
+          field           = field_selector.value.field
+          equals          = field_selector.value.equals
+          not_equals      = field_selector.value.not_equals
+          starts_with     = field_selector.value.starts_with
+          not_starts_with = field_selector.value.not_starts_with
+          ends_with       = field_selector.value.ends_with
+          not_ends_with   = field_selector.value.not_ends_with
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,26 @@ resource "aws_cloudtrail" "default" {
     }
   }
 
+  dynamic "advanced_event_selector" {
+    for_each = var.advanced_event_selector
+    content {
+      name = lookup(advanced_event_selector.value, "name", null)
+
+      dynamic "field_selector" {
+        for_each = lookup(advanced_event_selector.value, "field_selector", [])
+        content {
+          field           = field_selector.value.field
+          equals          = field_selector.value.equals
+          not_equals      = field_selector.value.not_equals
+          starts_with     = field_selector.value.starts_with
+          not_starts_with = field_selector.value.not_starts_with
+          ends_with       = field_selector.value.ends_with
+          not_ends_with   = field_selector.value.not_ends_with
+        }
+      }
+    }
+  }
+
   dynamic "insight_selector" {
     for_each = var.insight_selector
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -65,16 +65,8 @@ variable "event_selector" {
 
 variable "advanced_event_selector" {
   type = list(object({
-    name = string
-    field_selector = list(object({
-      field           = string
-      equals          = list(string)
-      not_equals      = list(string)
-      starts_with     = list(string)
-      not_starts_with = list(string)
-      ends_with       = list(string)
-      not_ends_with   = list(string)
-    }))
+    name           = string
+    field_selector = list(object({}))
   }))
 
   description = "Specifies advanced event selector for enabling data event logging. See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail.html for details on this variable"

--- a/variables.tf
+++ b/variables.tf
@@ -65,8 +65,11 @@ variable "event_selector" {
 
 variable "advanced_event_selector" {
   type = list(object({
-    name           = string
-    field_selector = list(object({}))
+    name = string
+    field_selector = list(object({
+      field     = string
+      condition = list(string)
+    }))
   }))
 
   description = "Specifies advanced event selector for enabling data event logging. See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail.html for details on this variable"

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,24 @@ variable "event_selector" {
   default     = []
 }
 
+variable "advanced_event_selector" {
+  type = list(object({
+    name = string
+    field_selector = list(object({
+      field           = string
+      equals          = list(string)
+      not_equals      = list(string)
+      starts_with     = list(string)
+      not_starts_with = list(string)
+      ends_with       = list(string)
+      not_ends_with   = list(string)
+    }))
+  }))
+
+  description = "Specifies advanced event selector for enabling data event logging. See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail.html for details on this variable"
+  default     = []
+}
+
 variable "kms_key_arn" {
   type        = string
   description = "Specifies the KMS key ARN to use to encrypt the logs delivered by CloudTrail"

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "advanced_event_selector" {
     name = string
     field_selector = list(object({
       field           = string
-      condition       = list(string)
+      equals          = list(string)
       not_equals      = list(string)
       starts_with     = list(string)
       not_starts_with = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -67,8 +67,13 @@ variable "advanced_event_selector" {
   type = list(object({
     name = string
     field_selector = list(object({
-      field     = string
-      condition = list(string)
+      field           = string
+      condition       = list(string)
+      not_equals      = list(string)
+      starts_with     = list(string)
+      not_starts_with = list(string)
+      ends_with       = list(string)
+      not_ends_with   = list(string)
     }))
   }))
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 4.11.0"
     }
   }
 }


### PR DESCRIPTION
Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail

## what
* Provide the filters to narrow down the scope of allowed operations like put, get etc., and also be able to define the s3 bucket to which we want the operations to be restricted to

## why
* Without these filters we cannot drill down the watch event type to single operation if desired and limit the operation to single s3 bucket if desired.
* 
## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail

